### PR TITLE
Mostrado de resultados en mapa #304

### DIFF
--- a/src/app/features/my-environment/components/search-and-result/search-and-result.component.html
+++ b/src/app/features/my-environment/components/search-and-result/search-and-result.component.html
@@ -38,7 +38,7 @@
                                 </h2>
                                 <div class="" *ngIf="true" id="pdfData">
                                     <div *ngFor="let ls of searchResults">
-                                        <h5 class="details">{{ ls.name }}</h5>
+                                        <h5 class="details" (click)="flyTo(ls.addresses)">{{ ls.name }}</h5>
                                         <mat-list class="result-container list-unstyled"
                                             *ngFor="let address of ls.addresses">
                                             <mat-list-item *ngIf="address.street_name">

--- a/src/app/features/my-environment/components/search-and-result/search-and-result.component.spec.ts
+++ b/src/app/features/my-environment/components/search-and-result/search-and-result.component.spec.ts
@@ -11,6 +11,7 @@ import { of } from 'rxjs';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { Zone } from 'src/app/shared/models/common/zone.model';
 import { EconomicActivity } from 'src/app/shared/models/common/economic-activity.model';
+import { MapboxService } from '../../../../shared/components/mapbox/service/mapbox.service';
 
 describe('SearchAndResultComponent', () => {
   let component: SearchAndResultComponent;
@@ -20,7 +21,11 @@ describe('SearchAndResultComponent', () => {
   let expGetResultsResponse: any;
   let expBreakpointResponse: string;
   let myEnvSrv: MyEnvironmentService;
- 
+
+  const fakeMapboxSrvMock = {
+    flyTo: jest.fn()
+  }
+
   const fakeCommonSrvMock = {
     getZones: jest.fn()
   }
@@ -51,8 +56,8 @@ describe('SearchAndResultComponent', () => {
       declarations: [SearchAndResultComponent],
       providers: [
         { provide: CommonService, useValue: fakeCommonSrvMock },
-        { provide: MyEnvironmentService, useValue: fakeEnvSrvMock }
-        //  {provide: BreakpointService, useValue: fakeBreakpointSrvMock}
+        { provide: MyEnvironmentService, useValue: fakeEnvSrvMock },
+        { provide: MapboxService, useValue : fakeMapboxSrvMock}
       ],
       schemas: [NO_ERRORS_SCHEMA]
     })
@@ -228,4 +233,13 @@ describe('SearchAndResultComponent', () => {
     expect(component.selectedActivities.length).toBe(1);
   });
 
-});
+ it('should call flyTo method', () => {
+const data = {lat: 1, lng: 1};
+const service = fixture.debugElement.injector.get(MapboxService);
+const spy = jest.spyOn(service, 'flyTo').mockImplementation(() => null);
+component.flyTo(data);
+expect(spy).toHaveBeenCalledWith(data);
+
+})
+
+})

--- a/src/app/features/my-environment/components/search-and-result/search-and-result.component.ts
+++ b/src/app/features/my-environment/components/search-and-result/search-and-result.component.ts
@@ -14,6 +14,7 @@ import { Zone } from 'src/app/shared/models/common/zone.model';
 import { MapboxMarkersService } from '../../services/mapbox-markers.service';
 
 import { Subscription } from 'rxjs';
+import { MapboxService } from '../../../../shared/components/mapbox/service/mapbox.service';
 
 @Component({
   selector: 'app-search-and-result',
@@ -50,6 +51,7 @@ export class SearchAndResultComponent implements OnInit {
     private responsive: BreakpointService,
     private myEnvSrv: MyEnvironmentService,
     private commonService: CommonService,
+    private MapboxService: MapboxService,
     private dialog: MatDialog) {
     const value = MY_ENVIRONMENT_MAT_GRID_LIST.get(this.responsive.getCurrentScreenSize());
     if (value != undefined) {
@@ -75,6 +77,10 @@ export class SearchAndResultComponent implements OnInit {
     if (this.businessModel <= 2) {
       this.getAllActivities(); //gets all the activities available from my environment service
     }
+  }
+
+  flyTo(data : any){
+    this.MapboxService.flyTo(data)
   }
 
   getAllZones() {
@@ -112,7 +118,6 @@ export class SearchAndResultComponent implements OnInit {
     this.businessModelSearch.activities = this.selectedActivities;
     this.businessModelSearch.zones = this.selectedZones;
     this.showResults = true;
-
     this.environments = this.myEnvSrv.getResults(this.businessModelSearch).subscribe((response: any) => {  
       response.results.forEach((result: any) => {
         this.searchResults.push({

--- a/src/app/shared/components/mapbox/mapbox.component.spec.ts
+++ b/src/app/shared/components/mapbox/mapbox.component.spec.ts
@@ -2,189 +2,223 @@ import { Popup } from 'mapbox-gl';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MapboxComponent } from './mapbox.component';
+import mapboxgl from 'mapbox-gl';
+import Marker from 'mapbox-gl';
 
-declare var global:any;
+declare var global: any;
 
-jest.mock('mapbox-gl/dist/mapbox-gl', () => ({
-
-    GeolocateControl: jest.fn(),
-    Marker: jest.fn(()=> ({
-      getLngLat: jest.fn().mockReturnValue({}),
-      setLngLat: jest.fn().mockReturnValue({
-        setPopup: jest.fn().mockReturnValue({
-          addTo: jest.fn().mockReturnValue({
-            getElement:jest.fn().mockReturnValue({
-              addEventListener: jest.fn().mockReturnValue({
-                getLngLat: jest.fn().mockReturnValue({
-                  remove: jest.fn().mockReturnValue({})
-                })
+jest.mock('mapbox-gl', () => ({
+  GeolocateControl: jest.fn(),
+  Marker: jest.fn(() => ({
+    getLngLat: jest.fn().mockReturnValue({}),
+    setLngLat: jest.fn().mockReturnValue({
+      setPopup: jest.fn().mockReturnValue({
+        addTo: jest.fn().mockReturnValue({
+          getElement: jest.fn().mockReturnValue({
+            addEventListener: jest.fn().mockReturnValue({
+              getLngLat: jest.fn().mockReturnValue({
+                remove: jest.fn().mockReturnValue({})
               })
             })
           })
         })
       })
-    })),
-    Popup: jest.fn().mockReturnValue({
-      setHTML: jest.fn().mockReturnValue({ on: jest.fn() })
-    }),
-    Map: jest.fn(() => ({
-      addControl: jest.fn(),
-      on: jest.fn(),
-      remove: jest.fn(),
-    })),
-    NavigationControl: jest.fn(),
-    LngLatBounds: jest.fn()
-    
+    })
+  })),
+  Popup: jest.fn().mockReturnValue({
+    setHTML: jest.fn().mockReturnValue({ on: jest.fn() })
+  }),
+  Map: jest.fn(() => ({
+    addControl: jest.fn(),
+    on: jest.fn(),
+    remove: jest.fn(),
+    fire: jest.fn(),
+  })),
+  NavigationControl: jest.fn(),
+  LngLatBounds: jest.fn()
+
 }));
 
 describe('MapboxComponent', () => {
 
-    let component: MapboxComponent, fixture: ComponentFixture<MapboxComponent>;
+  let component: MapboxComponent, fixture: ComponentFixture<MapboxComponent>;
 
-    const mockGeolocation = { getCurrentPosition: jest.fn(), watchPosition: jest.fn() };
-      
-    global.navigator.geolocation = mockGeolocation;
+  const mockGeolocation = { getCurrentPosition: jest.fn(), watchPosition: jest.fn() };
+
+  global.navigator.geolocation = mockGeolocation;
 
   const sampleBusiness = {
-      name: 'Compañia Roca Sanitario For Real',
-      web: 'https://www.roca.es',
-      email: "infosan@roca.net",
-      phone: null,
-     // activities: [],
-      addresses: [{
-        street_name: 'Av Diagonal',
-        street_number: "513",
-        zip_code: "08029",
-        district_id: "04",
-        town: "BARCELONA",
-        location: {
-          x: 2.140835,
-          y: 41.391424
-        },
+    name: 'Compañia Roca Sanitario For Real',
+    web: 'https://www.roca.es',
+    email: "infosan@roca.net",
+    phone: null,
+    // activities: [],
+    addresses: [{
+      street_name: 'Av Diagonal',
+      street_number: "513",
+      zip_code: "08029",
+      district_id: "04",
+      town: "BARCELONA",
+      location: {
+        x: 2.140835,
+        y: 41.391424
       },
+    },
     ],
-    }
+  }
 
-    const incorrectBusiness = {
-      name: 'Business with wrong coordinates',
-      web: 'https://www.roca.es',
-      email: "infosan@roca.net",
-      phone: null,
-     // activities: [],
-      addresses: [{
-        street_name: 'Av Diagonal',
-        street_number: "513",
-        zip_code: "08029",
-        district_id: "04",
-        town: "BARCELONA",
-        location: {
-          x: 23432,
-          y: 1232
-        },
+  const incorrectBusiness = {
+    name: 'Business with wrong coordinates',
+    web: 'https://www.roca.es',
+    email: "infosan@roca.net",
+    phone: null,
+    // activities: [],
+    addresses: [{
+      street_name: 'Av Diagonal',
+      street_number: "513",
+      zip_code: "08029",
+      district_id: "04",
+      town: "BARCELONA",
+      location: {
+        x: 23432,
+        y: 1232
       },
+    },
     ],
+  }
+
+  beforeEach(async () => {
+
+    await TestBed.configureTestingModule({
+      imports: [],
+      declarations: [MapboxComponent],
+      schemas: [NO_ERRORS_SCHEMA]
+    })
+      .compileComponents();
+
+  });
+
+  beforeEach(() => {
+
+    fixture = TestBed.createComponent(MapboxComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should create', () => {
+
+    expect(component).toBeTruthy();
+
+  });
+
+
+  it('current markers should be removed upon calling reset current Markers function', () => {
+
+    component.resetCurrentMarkers();
+
+    expect(component.currentMarkers.length).toEqual(0);
+
+  });
+
+
+  it('new Popup should be called upon createMarkerwithPopup', () => {
+    component.ngAfterViewInit();
+
+    component.createMarkerwithPopup('orange', sampleBusiness);
+
+    expect(new Popup().setHTML).toHaveBeenCalled();
+  });
+
+  it('On Destroy markers should be removed from current Markers', () => {
+    component.createMarkerwithPopup('orange', sampleBusiness);
+    console.log(component.currentMarkers, "testing Current Markers")
+    component.ngOnDestroy();
+
+    expect(component.currentMarkers.length).toEqual(0);
+  });
+
+
+  it('Get user location should have been called after view init', () => {
+    jest.spyOn(component, 'getUsersLocation');
+    const getLocation = component.getUsersLocation
+    component.ngAfterViewInit();
+
+    expect(getLocation).toHaveBeenCalled();
+  });
+
+
+  it('getCurrentPosition should be called when getUsersLocation executes', () => {
+
+    component.getUsersLocation();
+
+    expect(navigator.geolocation.getCurrentPosition).toHaveBeenCalled();
+  });
+
+  /*
+  it('currentMarkers should be increased when component executes createANewMarker', () => { 
+    
+    component.createANewMarker('orange', sampleBusiness );
+
+    expect(component.currentMarkers.length).toEqual(1);
+  });
+
+  */
+
+  it('Function CoordinatesAreValid should return true if business coordinates are valid', () => {
+
+    const testValid = component.coordinatesAreValid(sampleBusiness);
+
+    expect(testValid).toEqual(true);
+  });
+
+  it('Function CoordinatesAreValid should return false if business coordinates are invalid', () => {
+
+    const testValid = component.coordinatesAreValid(incorrectBusiness);
+
+    expect(testValid).toEqual(false);
+  });
+
+  /*
+  it('createNewMarker should call fitbounds', () => { 
+    
+    component.createANewMarker('color', sampleBusiness);
+
+    expect(component.map.fitBounds).toEqual(false);
+  });
+  */
+
+
+  it('get users location should call createANewMarker with red color if user doesnt share location', () => {
+
+    component.createANewMarker = jest.fn();
+    navigator.geolocation.getCurrentPosition = jest.fn().mockImplementationOnce((success, error) => error());
+
+    const spy = jest.spyOn(component, 'createANewMarker');
+    component.getUsersLocation()
+    expect(spy).toHaveBeenCalled()
+  } );
+
+  it('get users location should call createANewMarker with green color if user shares location', () => {
+      
+      component.createANewMarker = jest.fn();
+      const pos = { coords: { longitude: 2.140835, latitude: 41.391424 } }
+
+      navigator.geolocation.getCurrentPosition = jest.fn().mockImplementationOnce((success, error) => success(pos));
+
+      const spy = jest.spyOn(component, 'createANewMarker');
+
+      component.getUsersLocation()
+
+      expect(spy).toHaveBeenCalledWith('green', undefined, pos.coords);
     }
-    
-    beforeEach(async () => {
-
-        await TestBed.configureTestingModule({
-          imports: [ ],
-          declarations: [ MapboxComponent  ],
-          schemas: [NO_ERRORS_SCHEMA]    
-        })
-        .compileComponents();
-
-      });
-    
-      beforeEach(() => {
-
-        fixture = TestBed.createComponent(MapboxComponent);
-        component = fixture.componentInstance;
-        fixture.detectChanges();
-
-      });
-    
-      it('should create', () => { 
-
-        expect(component).toBeTruthy();
-
-      });
-      
-
-      it('current markers should be removed upon calling reset current Markers function', () => { 
-
-        component.resetCurrentMarkers();
-
-        expect(component.currentMarkers.length).toEqual(0);
-
-      });
-
-       
-      it('new Popup should be called upon createMarkerwithPopup', () => { 
-         component.ngAfterViewInit();
-       
-         component.createMarkerwithPopup('orange', sampleBusiness );
-
-         expect(new Popup().setHTML).toHaveBeenCalled();
-       });
-
-       it('On Destroy markers should be removed from current Markers', () => { 
-        component.createMarkerwithPopup('orange', sampleBusiness );
-        console.log(component.currentMarkers, "testing Current Markers")
-        component.ngOnDestroy();
-
-        expect(component.currentMarkers.length).toEqual(0);
-      });
+  );
 
 
-      it('Get user location should have been called after view init', () => { 
-        jest.spyOn(component, 'getUsersLocation');
-        const getLocation = component.getUsersLocation
-        component.ngAfterViewInit();
-
-        expect(getLocation).toHaveBeenCalled();
-      });
-
-      
-      it('getCurrentPosition should be called when getUsersLocation executes', () => { 
-
-        component.getUsersLocation();
-
-        expect(navigator.geolocation.getCurrentPosition).toHaveBeenCalled();
-      });
-
-      /*
-      it('currentMarkers should be increased when component executes createANewMarker', () => { 
-        
-        component.createANewMarker('orange', sampleBusiness );
-
-        expect(component.currentMarkers.length).toEqual(1);
-      });
-
-      */
-
-      it('Function CoordinatesAreValid should return true if business coordinates are valid', () => { 
-        
-        const testValid = component.coordinatesAreValid(sampleBusiness );
-
-        expect(testValid).toEqual(true);
-      });
-
-      it('Function CoordinatesAreValid should return false if business coordinates are invalid', () => { 
-        
-        const testValid = component.coordinatesAreValid(incorrectBusiness );
-
-        expect(testValid).toEqual(false);
-      });
-
-      /*
-      it('createNewMarker should call fitbounds', () => { 
-        
-        component.createANewMarker('color', sampleBusiness);
-
-        expect(component.map.fitBounds).toEqual(false);
-      });
-      */
 });
 
 

--- a/src/app/shared/components/mapbox/mapbox.component.ts
+++ b/src/app/shared/components/mapbox/mapbox.component.ts
@@ -38,8 +38,8 @@ export class MapboxComponent implements AfterViewInit {
         district_id: "04",
         town: "BARCELONA",
         location: {
-          x: 2.194060007737955,
-          y: 41.40389733660671,
+          y: 2.194060007737955,
+          x: 41.40389733660671,
         },
       },
     ],
@@ -75,7 +75,7 @@ export class MapboxComponent implements AfterViewInit {
     this.map = new Mapboxgl.Map({
       container: this.mapDivElement.nativeElement,
       style: environment.MAPBOX_STYLE,
-      center: [this.MAPBOX_INIT_LOCATION.addresses![0].location!.x, this.MAPBOX_INIT_LOCATION.addresses![0].location!.y], // starting center so it doesn't start from Germany
+      center: [this.MAPBOX_INIT_LOCATION.addresses![0].location!.y, this.MAPBOX_INIT_LOCATION.addresses![0].location!.x], // starting center so it doesn't start from Germany
       zoom: environment.MAPBOX_ZOOM,
       maxZoom: 18,
       accessToken: environment.MAPBOX_TOKEN

--- a/src/app/shared/components/mapbox/service/mapbox.service.spec.ts
+++ b/src/app/shared/components/mapbox/service/mapbox.service.spec.ts
@@ -1,0 +1,45 @@
+import { CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { LngLatLike, Map } from 'mapbox-gl';
+import { MapboxService } from './mapbox.service';
+
+
+
+
+
+describe('MapboxService', () => {
+  let service: MapboxService;
+  let mockMap: Map;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      schemas: [CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA],
+    });
+    service = TestBed.inject(MapboxService);
+    mockMap = {} as Map;
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should set map', () => {
+    service.setMap(mockMap);
+    expect(service.map).toEqual(mockMap);
+  });
+
+  it('should fly to a specific location', () => {
+    const mockCoords = [{ location: { x: 10, y: 20 } }];
+    const mockLngLat: LngLatLike = [mockCoords[0].location.y, mockCoords[0].location.x];
+    mockMap.flyTo = jest.fn();
+
+    service.setMap(mockMap);
+    service.flyTo(mockCoords);
+
+    expect(mockMap.flyTo).toHaveBeenCalledWith({
+      zoom: 20,
+      center: mockLngLat,
+    });
+  });
+
+});

--- a/src/app/shared/components/mapbox/service/mapbox.service.ts
+++ b/src/app/shared/components/mapbox/service/mapbox.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+
+import { LngLatLike, Map } from 'mapbox-gl';
+
+
+@Injectable({
+  providedIn: 'root'
+})
+export class MapboxService {
+
+  map!: Map;
+  
+  // Instance of mapbox map is passed from mapbox component
+  setMap(map: Map) {
+    this.map = map;
+  }
+
+  // Method to fly to a specific location 
+  flyTo(coords: any) {
+    const lengLat = [coords[0].location.y, coords[0].location.x] as LngLatLike;
+    this.map.flyTo({
+      zoom: 20,
+      center: lengLat,
+    })
+  }
+
+}


### PR DESCRIPTION
issue #304 

1 Se muestra la data de búsqueda en panel izquierdo (si la hay) y automáticamente se muestra en el mapa del panel derecho.

2 Los resultados se muestran en el mapa con un marcador de color naranja, diferente al de la geolocalización del usuario.

4 Al hacer click en el título del resultado del panel izquierdo, se posiciona el marcador del mapa en el centro del mismo y se hace un zoom de 20, de esta manera vemos su posición en el mapa con claridad. 
